### PR TITLE
商品出品機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ end
 
 gem 'pry-rails'
 gem 'devise'
+gem 'active_hash'
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.0)
+      activesupport (>= 5.0.0)
     activejob (6.0.3.4)
       activesupport (= 6.0.3.4)
       globalid (>= 0.3.6)
@@ -112,6 +114,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.5)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
@@ -268,6 +271,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
@@ -276,6 +280,7 @@ DEPENDENCIES
   faker
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   mysql2 (>= 0.4.4)
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/user/registration.css
+++ b/app/assets/stylesheets/user/registration.css
@@ -99,7 +99,7 @@
   flex-wrap: wrap;
 }
 
-.input-birth-wrap>select {
+.input-birth-wrap select {
   width: 75px;
   margin-top: 5px;
   height: 45px;
@@ -111,10 +111,15 @@
   cursor: pointer;
 }
 
-.input-birth-wrap>p {
+.input-birth-wrap p {
   line-height: 60px;
   padding: 0 5px;
 }
+
+.field_with_errors {
+  display: contents;
+}
+
 
 .form-bottom-text {
   font-size: 15px;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
+   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
   def configure_permitted_parameters

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,2 +1,46 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, only: [:new]
+
+  def index
+    @items = Item.all
+    flash[:notice] = "ログイン済ユーザーのみ出品できます" unless user_signed_in?
+  end
+
+  def new
+    @item = Item.new
+    
+  end
+
+  def create
+    @item = Item.new(item_params)
+    if @item.valid?
+      @item.save
+      redirect_to root_path
+    else
+      render :new
+    end
+  end
+
+
+  def edit
+  end
+
+  def update
+    @item.update(item_params)
+    redirect_to root_path
+  end
+
+
+
+  private
+  def item_params
+    params.require(:item).permit(:image, :name, :explanation, :category_id, :condition_id, :delivery_fee_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
+  end
+
+
+  def move_to_index
+    unless user_signed_in?
+      redirect_to action: :index
+    end
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,10 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
-  def index
-    @items = Item.all
-    flash[:notice] = "ログイン済ユーザーのみ出品できます" unless user_signed_in?
-  end
+  # def index
+  #   @items = Item.all
+  #   flash[:notice] = "ログイン済ユーザーのみ出品できます" unless user_signed_in?
+  # end
 
   def new
     @item = Item.new
@@ -22,13 +22,13 @@ class ItemsController < ApplicationController
   end
 
 
-  def edit
-  end
+  # def edit
+  # end
 
-  def update
-    @item.update(item_params)
-    redirect_to root_path
-  end
+  # def update
+  #   @item.update(item_params)
+  #   redirect_to root_path
+  # end
 
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,11 +36,4 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:image, :name, :explanation, :category_id, :condition_id, :delivery_fee_id, :prefecture_id, :shipping_day_id, :price).merge(user_id: current_user.id)
   end
-
-
-  def move_to_index
-    unless user_signed_in?
-      redirect_to action: :index
-    end
-  end
 end

--- a/app/javascript/item_price.js
+++ b/app/javascript/item_price.js
@@ -1,0 +1,13 @@
+window.addEventListener("load", function () {
+  
+  const priceInput = document.getElementById("item-price");
+  priceInput.addEventListener('input', function () {
+    const inputValue = priceInput.value;
+    const addTaxDom = document.getElementById("add-tax-price");
+    const fee = Math.floor(inputValue / 10);
+    addTaxDom.innerHTML = fee;
+    const addProfitDom = document.getElementById("profit");
+    addProfitDom.innerHTML = (inputValue - fee );
+  });
+
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,7 +6,7 @@
 require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
-
+require("../item_price");
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,19 @@
+class Category < ActiveHash::Base
+  self.data = [
+    { id: 1,  name:  '--' },
+    { id: 2,  name:  'レディース' },
+    { id: 3,  name:  'メンズ' },
+    { id: 4,  name:  'ベビー・キッズ' },
+    { id: 5,  name:  'インテリア・住まい・小物' },
+    { id: 6,  name:  '本・音楽・ゲーム' },
+    { id: 7,  name:  'おもちゃ・ホビー・グッズ' },
+    { id: 8,  name:  '家電・スマホ・カメラ' },
+    { id: 9,  name:  'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
+  ]
+ 
+   include ActiveHash::Associations
+   has_many :items
+ 
+  end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,15 @@
+class Condition < ActiveHash::Base
+  self.data = [
+    { id: 1,  name:  '--' },
+    { id: 2,  name:  '新品、未使用' },
+    { id: 3,  name:  '未使用に近い' },
+    { id: 4,  name:  '目立った傷や汚れなし' },
+    { id: 5,  name:  'やや傷や汚れあり' },
+    { id: 6,  name:  '傷や汚れあり' },
+    { id: 7,  name:  '全体的に状態が悪い' }
+  ]
+ 
+   include ActiveHash::Associations
+   has_many :items
+ 
+  end

--- a/app/models/delivery_fee.rb
+++ b/app/models/delivery_fee.rb
@@ -1,0 +1,11 @@
+class DeliveryFee < ActiveHash::Base
+  self.data = [
+    { id: 1,  name:  '--' },
+    { id: 2,  name:  '着払い(購入者負担)' },
+    { id: 3,  name:  '送料込み(出品者負担)' },
+  ]
+ 
+   include ActiveHash::Associations
+   has_many :items
+ 
+  end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,27 +1,27 @@
 class Item < ApplicationRecord
-  belongs_to :user
-  has_one_attached :image
+    belongs_to :user
+    has_one_attached :image
 
-  extend ActiveHash::Associations::ActiveRecordExtensions
-  belongs_to :category
-  belongs_to :condition
-  belongs_to :delivery_fee
-  belongs_to :prefecture
-  belongs_to :shipping_day
+    extend ActiveHash::Associations::ActiveRecordExtensions
+    belongs_to :category
+    belongs_to :condition
+    belongs_to :delivery_fee
+    belongs_to :prefecture
+    belongs_to :shipping_day
 
-  validates :image,            presence: true
-  validates :name,             length: { maximum: 40 }, presence: true
-  validates :explanation,      length: { maximum: 1000 }, presence: true
 
-  validates :category_id, :condition_id, :delivery_fee_id,
-              numericality: { other_than: 1 }, presence: true
-
-  validates :prefecture_id, :shipping_day_id,  
-                numericality: { other_than: 0 }, presence: true
-
-  validates :price, 
-             numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 },
-             presence: true
+    with_options presence: true do
+      
+    validates :image
+    validates :name,             length: { maximum: 40 }
+    validates :explanation,      length: { maximum: 1000 }
+    validates :category_id, :condition_id, :delivery_fee_id,
+                numericality: { other_than: 1 }
+    validates :prefecture_id, :shipping_day_id,  
+                  numericality: { other_than: 0 }
+    validates :price, 
+               numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
+    end
 end
 
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,27 @@
+class Item < ApplicationRecord
+  belongs_to :user
+  has_one_attached :image
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :category
+  belongs_to :condition
+  belongs_to :delivery_fee
+  belongs_to :prefecture
+  belongs_to :shipping_day
+
+  validates :image,            presence: true
+  validates :name,             length: { maximum: 40 }, presence: true
+  validates :explanation,      length: { maximum: 1000 }, presence: true
+
+  validates :category_id, :condition_id, :delivery_fee_id,
+              numericality: { other_than: 1 }, presence: true
+
+  validates :prefecture_id, :shipping_day_id,  
+                numericality: { other_than: 0 }, presence: true
+
+  validates :price, 
+             numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 },
+             presence: true
+end
+
+

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,25 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+    { id: 0, name:  '--' },
+    {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+    {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+    {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+    {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+    {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+    {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+    {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+    {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+    {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+    {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+    {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+    {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+    {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+    {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+    {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+    {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+]
+ 
+   include ActiveHash::Associations
+   has_many :items
+ 
+  end

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -1,0 +1,12 @@
+class ShippingDay  < ActiveHash::Base
+  self.data = [
+    { id: 0,  name:  '--' },
+    { id: 1,  name:  '1~2日で発送' },
+    { id: 2,  name:  '2~3日で発送' },
+    { id: 3,  name:  '4~7日で発送' },
+  ]
+ 
+   include ActiveHash::Associations
+   has_many :items
+ 
+  end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,11 +4,13 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+  has_many :items
+
 
   
   validates :nickname, presence: true
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }
-   #漢字と全角の平仮名とカタカナのバリデーション
+ #漢字と全角の平仮名とカタカナのバリデーション
   VALID_NAME_REGEX = /\A[ぁ-んァ-ン一-龥]/
   validates :last_name, :first_name, presence: true, format: { with: VALID_NAME_REGEX, message: "は全角で入力してください" }
  #全角カタカナ

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -180,7 +180,7 @@
   </div>
   <%# /商品一覧 %>
 </div>
-<%= link_to('#', class: 'purchase-btn') do %>
+<%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
 <% end %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -7,10 +7,9 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+    
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,10 +5,10 @@
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 出品画像 %>
@@ -21,7 +21,7 @@
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -31,13 +31,13 @@
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -50,12 +50,12 @@
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:delivery_fee_id, DeliveryFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -99,7 +99,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: :index
+  resources :items
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20201113032135_create_items.rb
+++ b/db/migrate/20201113032135_create_items.rb
@@ -1,0 +1,17 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.references :user,               null: false, foreign_key: true
+      t.string     :name,               null: false
+      t.text       :explanation,        null: false
+      t.integer    :category_id,        null: false
+      t.integer    :condition_id,       null: false
+      t.integer    :delivery_fee_id,    null: false
+      t.integer    :prefecture_id,      null: false
+      t.integer    :shipping_day_id,    null: false
+      t.integer    :price,              null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201113035200_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20201113035200_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_11_095406) do
+ActiveRecord::Schema.define(version: 2020_11_13_035200) do
+
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.text "explanation", null: false
+    t.integer "category_id", null: false
+    t.integer "condition_id", null: false
+    t.integer "delivery_fee_id", null: false
+    t.integer "prefecture_id", null: false
+    t.integer "shipping_day_id", null: false
+    t.integer "price", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
@@ -30,4 +66,6 @@ ActiveRecord::Schema.define(version: 2020_11_11_095406) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "items", "users"
 end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    
+  end
+end

--- a/spec/factories/conditions.rb
+++ b/spec/factories/conditions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :condition do
+    
+  end
+end

--- a/spec/factories/delivery_fees.rb
+++ b/spec/factories/delivery_fees.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :delivery_fee do
+    
+  end
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :item do
+      name {"テスト"}
+      explanation {"衣類"}
+      category_id {2}
+      condition_id {2}
+      delivery_fee_id {3}
+      prefecture_id {4}
+      shipping_day_id {5}
+      price {34568}
+      association :user
+      after(:build) do |item|
+        item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
+      end
+  end
+end

--- a/spec/factories/prefectures.rb
+++ b/spec/factories/prefectures.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :prefecture do
+    
+  end
+end

--- a/spec/factories/shipping_days.rb
+++ b/spec/factories/shipping_days.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :shipping_day do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :user do
     nickname              {Faker::Name.initials(number: 2)}
     email                 {Faker::Internet.free_email}
-    password              {Faker::Internet.password(min_length: 6)}
+    password              {"111aaa"}
     password_confirmation {password}
     first_name {"阿部"}
     last_name {"優子"}

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Condition, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/delivery_fee_spec.rb
+++ b/spec/models/delivery_fee_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DeliveryFee, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -14,6 +14,13 @@ describe Item, type: :model do
     end
   
 
+    it "商品画像がないと出品できない" do
+      @item.image = nil
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Image can't be blank")
+    end
+
+
     it "商品名がないと出品できない" do
       @item.name = ""
       @item.valid?
@@ -66,6 +73,13 @@ describe Item, type: :model do
       @item.shipping_day_id = 0
       @item.valid?
       expect(@item.errors.full_messages).to include("Shipping day must be other than 0")
+    end
+
+
+    it "配送料負担--を選ぶと出品できない" do
+      @item.delivery_fee_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
     end
 
     it "金額が入ってないと出品できない" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe Item, type: :model do
+  describe '#create' do
+    before do
+      user = FactoryBot.create(:user)
+      @item = FactoryBot.build(:item, user_id: user.id)
+    end
+
+
+
+    it "必要事項が入力されていれば出品できる" do
+      expect(@item).to be_valid
+    end
+  
+
+    it "商品名がないと出品できない" do
+      @item.name = ""
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Name can't be blank")
+    end
+
+
+    it "商品名が41文字以上だと出品できない" do
+      @item.name = "a" * 41
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Name is too long (maximum is 40 characters)")
+    end
+
+
+    it "商品説明がないと出品できない" do
+      @item.explanation = ""
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Explanation can't be blank")
+    end
+
+
+    it "商品説明が1001文字以上だと出品できない" do
+      @item.explanation = "a" * 1001
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Explanation is too long (maximum is 1000 characters)")
+    end
+
+
+
+    it "カテゴリ--を選ぶと出品できない" do
+      @item.category_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Category must be other than 1")
+    end
+
+    it "商品状態--を選ぶと出品できない" do
+      @item.condition_id = 1
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Condition must be other than 1")
+    end
+
+
+    it "都道府県--を選ぶと出品できない" do
+      @item.prefecture_id = 0
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Prefecture must be other than 0")
+    end
+
+    it "発送日数--を選ぶと出品できない" do
+      @item.shipping_day_id = 0
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Shipping day must be other than 0")
+    end
+
+    it "金額が入ってないと出品できない" do
+      @item.price = "あああ"
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Price is not a number")
+    end
+
+    it "商品価格が299円以下だと出品できない" do
+      @item.price = 299
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+    end
+
+    it "商品価格が10000000円以上だと出品できない" do
+      @item.price = 10000000
+      @item.valid?
+      expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+    end
+  end
+end
+
+
+

--- a/spec/models/prefecture_spec.rb
+++ b/spec/models/prefecture_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Prefecture, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/shipping_day_spec.rb
+++ b/spec/models/shipping_day_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ShippingDay, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# what
フリマアプリに登録できる商品出品ページを作成
# why
アプリに会員登録し、さらにログインしてるユーザだけが出品できるようにするため
<br><br>


### 出品に失敗しエラーが表示される ###
![出品失敗](https://gyazo.com/78f8da17c7575dfb5bb0b6826d3f787c.gif)
<br>
<br><br>

### ログインしていないユーザーが出品しようとするとログインページへリダイレクトされる ###
![未会員](https://gyazo.com/c5f8756b0755e54843140fee270d10f0.gif)
<br>
<br><br>
### 非同期的に販売手数料や販売利益が変わる ###
![画面収録-2020-11-14-23 35 04](https://user-images.githubusercontent.com/67476247/99149568-422a7b00-26d2-11eb-9a89-c698246c19ac.gif)

### テスト ###
![テスト](https://gyazo.com/b605f9f6dfee2ad148981345e74c0e05.png)
