### PR TITLE
エラーメッセージ日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,5 @@ gem "aws-sdk-s3", require: false
 gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 gem "omniauth-rails_csrf_protection"
+
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -356,6 +359,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails (~> 4.0.0)
   rubocop

--- a/app/models/items_tag.rb
+++ b/app/models/items_tag.rb
@@ -9,11 +9,11 @@ class ItemsTag
     validates :name,             length: { maximum: 40 }
     validates :explanation,      length: { maximum: 1000 }
     validates :category_id, :condition_id, :delivery_fee_id,
-                numericality: { other_than: 0 }
+                numericality: { other_than: 0, message: "を選択してください" }
     validates :prefecture_id, :shipping_day_id,  
-                  numericality: { other_than: 0 }
+                  numericality: { other_than: 0, message: "を選択してください" }
     validates :price, 
-               numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
+               numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "半角数字で入力してください" }
     end
   
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,12 +7,12 @@ class Order
 
   with_options presence: true do
     # 郵便番号に関するバリデーション
-    validates :postal_code, format: {with:/\A\d{3}[-]\d{4}\z/, message: " input correctly"}
+    validates :postal_code, format: {with:/\A\d{3}[-]\d{4}\z/}
     # 都道府県に関するバリデーション
-    validates :prefecture_id, numericality: { other_than: 0, message: "can't be blank" }
+    validates :prefecture_id, numericality: { other_than: 0}
     validates :city
     validates :house_number
-    validates :phone_number, format: {with: /\A[0-9]+\z/, message: "input only number"}
+    validates :phone_number, format: {with: /\A[0-9]+\z/}
 
     validates :token
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,8 @@ module Furima28113
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        message_unconfirmed: 
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,46 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        last_name: 姓
+        first_name: 名前
+        last_name_kana: 姓フリガナ
+        first_name_kana: 名前フリガナ
+        birthday: 生年月日
+
+  activemodel:
+    attributes:
+      order:
+        postal_code: 郵便番号
+        city: 市区町村
+        prefecture_id: 都道府県
+        house_number: 番地
+        phone_number: 電話番号
+        token: クレジットカード情報
+
+     
+      items_tag:
+        image: 画像
+        name: 商品名
+        explanation: 商品説明
+        category_id: カテゴリー
+        price: 価格
+        condition_id: 商品の状態
+        delivery_fee_id: 配送料金
+        shipping_day_id: 配送日
+        prefecture_id: 都道府県
+
+
+
+        
+
+
+ 
+
+
+
+
+
+
+

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,87 +17,87 @@ describe Item, type: :model do
     it "商品画像がないと出品できない" do
       @item.image = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
+      expect(@item.errors.full_messages).to include("Imageを入力してください")
     end
 
 
     it "商品名がないと出品できない" do
       @item.name = ""
       @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
+      expect(@item.errors.full_messages).to include("Nameを入力してください")
     end
 
 
     it "商品名が41文字以上だと出品できない" do
       @item.name = "a" * 41
       @item.valid?
-      expect(@item.errors.full_messages).to include("Name is too long (maximum is 40 characters)")
+      expect(@item.errors.full_messages).to include("Nameは40文字以内で入力してください")
     end
 
 
     it "商品説明がないと出品できない" do
       @item.explanation = ""
       @item.valid?
-      expect(@item.errors.full_messages).to include("Explanation can't be blank")
+      expect(@item.errors.full_messages).to include("Explanationを入力してください")
     end
 
 
     it "商品説明が1001文字以上だと出品できない" do
       @item.explanation = "a" * 1001
       @item.valid?
-      expect(@item.errors.full_messages).to include("Explanation is too long (maximum is 1000 characters)")
+      expect(@item.errors.full_messages).to include("Explanationは1000文字以内で入力してください")
     end
 
 
 
     it "カテゴリ--を選ぶと出品できない" do
-      @item.category_id = 1
+      @item.category_id = 0
       @item.valid?
-      expect(@item.errors.full_messages).to include("Category must be other than 1")
+      expect(@item.errors.full_messages).to include("Categoryは0以外の値にしてください")
     end
 
     it "商品状態--を選ぶと出品できない" do
-      @item.condition_id = 1
+      @item.condition_id = 0
       @item.valid?
-      expect(@item.errors.full_messages).to include("Condition must be other than 1")
+      expect(@item.errors.full_messages).to include("Conditionは0以外の値にしてください")
     end
 
 
     it "都道府県--を選ぶと出品できない" do
       @item.prefecture_id = 0
       @item.valid?
-      expect(@item.errors.full_messages).to include("Prefecture must be other than 0")
+      expect(@item.errors.full_messages).to include("Prefectureは0以外の値にしてください")
     end
 
     it "発送日数--を選ぶと出品できない" do
       @item.shipping_day_id = 0
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping day must be other than 0")
+      expect(@item.errors.full_messages).to include("Shipping dayは0以外の値にしてください")
     end
 
 
     it "配送料負担--を選ぶと出品できない" do
-      @item.delivery_fee_id = 1
+      @item.delivery_fee_id = 0
       @item.valid?
-      expect(@item.errors.full_messages).to include("Delivery fee must be other than 1")
+      expect(@item.errors.full_messages).to include("Delivery feeは0以外の値にしてください")
     end
 
     it "金額が入ってないと出品できない" do
       @item.price = "あああ"
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price is not a number")
+      expect(@item.errors.full_messages).to include("Priceは数値で入力してください")
     end
 
     it "商品価格が299円以下だと出品できない" do
       @item.price = 299
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+      expect(@item.errors.full_messages).to include("Priceは300以上の値にしてください")
     end
 
     it "商品価格が10000000円以上だと出品できない" do
       @item.price = 10000000
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+      expect(@item.errors.full_messages).to include("Priceは9999999以下の値にしてください")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,13 +26,14 @@ describe User do
         it "nicknameが空だと登録できない" do
           @user.nickname = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("Nickname can't be blank")
+          expect(@user.errors.full_messages).to include("ニックネームを入力してください")
+          
         end
 
         it "emailが空では登録できない" do
           @user.email = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("Email can't be blank")
+          expect(@user.errors.full_messages).to include("Eメールを入力してください")
         end
 
         it "重複したemailが存在する場合登録できない" do
@@ -40,13 +41,13 @@ describe User do
           another_user = FactoryBot.build(:user)
           another_user.email = @user.email
           another_user.valid?
-          expect(another_user.errors.full_messages).to include("Email has already been taken")
+          expect(another_user.errors.full_messages).to include("Eメールはすでに存在します")
         end
 
         it "passwordが空では登録できない" do
           @user.password = ""
-          @user.valid?
-          expect(@user.errors.full_messages).to include("Password can't be blank")
+          @user.valid?  
+          expect(@user.errors.full_messages).to include("パスワードを入力してください", "パスワードは不正な値です", "パスワード（確認用）とパスワードの入力が一致しません")
         end
 
 
@@ -54,43 +55,43 @@ describe User do
           @user.password = "00000"
           @user.password_confirmation = "00000"
           @user.valid?
-          expect(@user.errors.full_messages).to include("Password is too short (minimum is 6 characters)")
+          expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください", "パスワードは不正な値です")
         end
         
         it "passwordが存在してもpassword_confirmationが空では登録できない" do
           @user.password_confirmation =""
           @user.valid?
-          expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+          expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
         end
         
         it "birthdayが空では登録できない" do
           @user.birthday = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("Birthday can't be blank")
+          expect(@user.errors.full_messages).to include("生年月日を入力してください")
         end
 
         it "名字が空では登録できない" do
           @user.last_name = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("Last name can't be blank")
+          expect(@user.errors.full_messages).to include("姓を入力してください", "姓は全角で入力してください")
         end
 
         it "名前が空では登録できない" do
           @user.first_name = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("First name can't be blank")
+          expect(@user.errors.full_messages).to include("名前を入力してください", "名前は全角で入力してください")
         end
 
         it "名字カナが空では登録できない" do
           @user.last_name_kana = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("Last name kana can't be blank")
+          expect(@user.errors.full_messages).to include("姓フリガナを入力してください", "姓フリガナは全角カナで入力してください")
         end
 
         it "名前カナが空では登録できない" do
           @user.first_name_kana = ""
           @user.valid?
-          expect(@user.errors.full_messages).to include("First name kana can't be blank")
+          expect(@user.errors.full_messages).to include("名前フリガナを入力してください", "名前フリガナは全角カナで入力してください")
         end
       end
     end


### PR DESCRIPTION
# what 
エラーメッセージを日本語化することで、なぜ登録に失敗するのか？出品できないのか？購入できないのか？をわかりやすくするため